### PR TITLE
Update maintenance_server_configuration.md

### DIFF
--- a/doc/maintenance_server_configuration.md
+++ b/doc/maintenance_server_configuration.md
@@ -89,7 +89,7 @@ Defaults:
 "locator": {
     "hostname": "",
     "endpoint": "::",
-    "port": "10053",
+    "port": 10053,
     "port-range": ""
 }
 ```


### PR DESCRIPTION
Fix port option in locator description. Value in double commas is a string, but port parametr must be numeric value.
